### PR TITLE
fix: don't include double quotes in filter strings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,9 +70,9 @@ runs:
         if [ "${{ inputs.working-dir == '' }}" = 'false' ]; then
           cd "${{ inputs.working-dir }}"
         fi
-        npx npm-check-updates -u --filter "\"${{ inputs.filter }}"\" --reject "\"${{ inputs.reject }}"\"
+        npx npm-check-updates -u --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
         if [ -e lerna.json ]; then
-          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --target minor --filter "\"${{ inputs.filter }}"\" --reject "\"${{ inputs.reject }}"\"
+          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --target minor --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
         fi
       shell: bash
     - name: minor - update package locks
@@ -115,9 +115,9 @@ runs:
         if [ "${{ inputs.working-dir == '' }}" = 'false' ]; then
           cd "${{ inputs.working-dir }}"
         fi
-        npx npm-check-updates -u --filter "\"${{ inputs.filter }}"\" --reject "\"${{ inputs.reject }}"\"
+        npx npm-check-updates -u --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
         if [ -e lerna.json ]; then
-          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --filter "\"${{ inputs.filter }}"\" --reject "\"${{ inputs.reject }}"\"
+          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
         fi
       shell: bash
     - name: major - update package locks


### PR DESCRIPTION
`"\"${{ inputs.filter }}"\"` unwraps to `""whatever search string""` which makes the search string `"whatever search string"` when what it should be is just `whatever search string`. `'${{ inputs.filter }}'` on the other hand unwraps to `'whatever search string'` which makes the search string `whatever search string` which is what we need.

Eg:
Bad
<img width="742" alt="image" src="https://user-images.githubusercontent.com/1926537/138713757-77ffd365-9c80-4f01-8a4b-149c6a8a5920.png">
Good
<img width="676" alt="image" src="https://user-images.githubusercontent.com/1926537/138713868-2efee582-5b78-499e-a107-0755b72ed192.png">
