### PR TITLE
fix: do include quotes in filter strings, but only for the lerna commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         fi
         npx npm-check-updates -u --target minor --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
         if [ -e lerna.json ]; then
-          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --target minor --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
+          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --target minor --filter "'${{ inputs.filter }}'" --reject "'${{ inputs.reject }}'"
         fi
       shell: bash
     - name: minor - update package locks
@@ -117,7 +117,7 @@ runs:
         fi
         npx npm-check-updates -u --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
         if [ -e lerna.json ]; then
-          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --filter '${{ inputs.filter }}' --reject '${{ inputs.reject }}'
+          npx lerna exec --concurrency=1 --stream=true -- npx npm-check-updates -u --filter "'${{ inputs.filter }}'" --reject "'${{ inputs.reject }}'"
         fi
       shell: bash
     - name: major - update package locks


### PR DESCRIPTION
The top level npm-check-updates calls need their filter strings not to be double quoted, since it's a normal shell. When lerna executes the call for the lerna packages though it does need the strings to be double quoted as they're first parsed by lerna before being passed to the shell.