### PR TITLE
fix: trying to add a package lock that is unchanged should not throw

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,11 @@ runs:
             for FILE in $(git status --porcelain | grep -o "\S*package\.json")
             do
               git add "$FILE"
-              git add "$(echo $FILE | sed 's|package\.|package-lock.|')" || true
+              if [ -e "$(echo $FILE | sed 's|package\.|package-lock.|')" ]; then
+                do
+                  git add "$(echo $FILE | sed 's|package\.|package-lock.|')" || true
+                done
+              fi
             done
           fi
           git config user.email "${{ inputs.commit-author }}@users.noreply.github.com"


### PR DESCRIPTION
Currently for each changed package.json we add the package-lock. Occasionally the package lock will
not exist; in these cases an error is thrown when trying to add the non existent file. This change checks the file exists before attempting to add it.